### PR TITLE
Fix dark-mode initial load and OS response

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@11ty/eleventy": "3.0.0-alpha.5"
+    "@11ty/eleventy": "3.0.0-alpha.10"
   },
   "dependencies": {
     "@11ty/eleventy-fetch": "^4.0.1",

--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -4,12 +4,37 @@ let darkModeState = false;
 
 // MediaQueryList object
 const useDark = window.matchMedia("(prefers-color-scheme: dark)");
+const useLight = window.matchMedia("(prefers-color-scheme: light)");
+
+// Initial setting
+if (
+	localStorage.getItem("dark-mode") == "true" ||
+	useDark.media === "not all" ||
+	useDark.matches === true
+) {
+	console.log("dark");
+	document.documentElement.classList.toggle("dark-mode", true);
+	toggleDarkMode(true);
+} else {
+	console.log("not dark");
+	document.documentElement.classList.toggle("dark-mode", false);
+	toggleDarkMode(false);
+}
+
+// Listen for changes in the OS settings.
+// Note: the arrow function shorthand works only in modern browsers,
+// for older browsers define the function using the function keyword.
+useDark.addEventListener("change", (e) => e.matches && toggleDarkMode(true));
+useLight.addEventListener("change", (e) => e.matches && toggleDarkMode(false));
+
 const colorSchemeEvent = new Event("trigger-color-scheme");
 
 // Toggles the "dark-mode" class
 function toggleDarkMode(state) {
+	console.log(state);
 	document.documentElement.classList.toggle("dark-mode", state);
 	darkModeState = state;
+	setDarkModeLocalStorage(darkModeState);
 }
 
 // Sets localStorage state
@@ -17,20 +42,11 @@ function setDarkModeLocalStorage(state) {
 	localStorage.setItem("dark-mode", state);
 }
 
-// Initial setting
-toggleDarkMode(localStorage.getItem("dark-mode") == "true");
-
-// Listen for changes in the OS settings.
-// Note: the arrow function shorthand works only in modern browsers,
-// for older browsers define the function using the function keyword.
-useDark.addListener((evt) => toggleDarkMode(evt.matches));
-
-window.addEventListener('load', () => {
+window.addEventListener("load", () => {
 	// Toggles the "dark-mode" class on click and sets localStorage state
 	const colorSchemeButton = document.querySelector(".toggle-color-scheme");
 	colorSchemeButton.addEventListener("click", () => {
 		darkModeState = !darkModeState;
-
 		toggleDarkMode(darkModeState);
 		setDarkModeLocalStorage(darkModeState);
 		document.documentElement.dispatchEvent(colorSchemeEvent);

--- a/src/assets/script.js
+++ b/src/assets/script.js
@@ -12,11 +12,9 @@ if (
 	useDark.media === "not all" ||
 	useDark.matches === true
 ) {
-	console.log("dark");
 	document.documentElement.classList.toggle("dark-mode", true);
 	toggleDarkMode(true);
 } else {
-	console.log("not dark");
 	document.documentElement.classList.toggle("dark-mode", false);
 	toggleDarkMode(false);
 }
@@ -31,7 +29,6 @@ const colorSchemeEvent = new Event("trigger-color-scheme");
 
 // Toggles the "dark-mode" class
 function toggleDarkMode(state) {
-	console.log(state);
 	document.documentElement.classList.toggle("dark-mode", state);
 	darkModeState = state;
 	setDarkModeLocalStorage(darkModeState);


### PR DESCRIPTION
This makes it so those of us with OS set to dark get dark mode on initial load and now local storage updates with OS and whenever the visitor clicks the toggle button. Also updated Eleventy v3 to canary 10.